### PR TITLE
Update docker run args invocation for new version

### DIFF
--- a/commands
+++ b/commands
@@ -213,7 +213,7 @@ EOF
 
     VOLUME="$VOLUME_DIR:/rethinkdb"
 
-    docker run -u $(id -u $RUNAS_USER) -v $VOLUME -name=$CONTAINER_NAME \
+    docker run -u $(id -u $RUNAS_USER) -v $VOLUME --name=$CONTAINER_NAME \
         ${PORTS[@]} -d $RETHINKDB_IMAGE --bind all
 
     # Save all dynamic port bindings as static bindings


### PR DESCRIPTION
When running `dokku rethinkdb:start [whatever]` the script currently spits out the following warning:

```
Warning: '-name' is deprecated, it will be replaced by '--name' soon. See usage.
```

This is the offending line:

``` bash
docker run -u $(id -u $RUNAS_USER) -v $VOLUME -name=$CONTAINER_NAME \
```

It runs correctly, but just to be safe I updated it.
