### PR TITLE
Updated to use latest rethinkdb image 2.0.4

### DIFF
--- a/commands
+++ b/commands
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
-RETHINKDB_IMAGE=rethinkdb:1.16.3
+RETHINKDB_IMAGE=rethinkdb:2.0.4
 
 PENDING_DIR="$DOKKU_ROOT/.rethinkdb/pending-volumes"
 

--- a/install
+++ b/install
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
-RETHINKDB_IMAGE=rethinkdb:1.16.0
+RETHINKDB_IMAGE=rethinkdb:2.0.4
 
 PENDING_DIR="$DOKKU_ROOT/.rethinkdb/pending-volumes"
 


### PR DESCRIPTION
Updated to use latest rethinkdb image 2.0.4, compatible with latest rethinkdb drivers 2.0.0-2.
